### PR TITLE
Add gh links to DESCRIPTION + update gh action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,7 +1,9 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
+    branches: [main, master]
+  pull_request:
     branches: [main, master]
   release:
     types: [published]
@@ -12,24 +14,35 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Deploy package
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Description: Estimates hazard ratios and mortality
     differentials for doubly-truncated data without population
     denominators.
 License: GPL (>= 3)
-URL: https://caseybreen.github.io/gompertztrunc/
+URL: https://caseybreen.github.io/gompertztrunc/, https://github.com/caseybreen/gompertztrunc
+BugReports: https://github.com/caseybreen/gompertztrunc/issues
 Depends: 
     R (>= 3.5.0)
 Imports: 


### PR DESCRIPTION
For discoverability and linking https://blog.r-hub.io/2019/12/10/urls/

Updated gh action to the latest workflow with `usethis::use_github_action('pkgdown')`.